### PR TITLE
添加一个 deployFormattedData 方法

### DIFF
--- a/class/Gini/BPM/Camunda/Engine.php
+++ b/class/Gini/BPM/Camunda/Engine.php
@@ -183,7 +183,7 @@ class Engine implements \Gini\BPM\Driver\Engine {
         $engine = $this->config['options']['engine'];
 
         if(empty($files)) {
-            throw new \Gini\BPM\Exception("Empty files");
+            throw new \Gini\BPM\Exception("empty files", 400);
         }
 
         $data = [];

--- a/class/Gini/BPM/Camunda/Engine.php
+++ b/class/Gini/BPM/Camunda/Engine.php
@@ -217,7 +217,7 @@ class Engine implements \Gini\BPM\Driver\Engine {
         $data   = json_decode($response->body, true);
 
         if (floor($status->code / 100) != 2) {
-            throw new \Gini\BPM\Exception($status->code . ': ' . $data['message'], $status->code);
+            throw new \Gini\BPM\Exception($status->code . ': ' . $data['message']);
         }
 
         return $data;

--- a/class/Gini/BPM/Camunda/Engine.php
+++ b/class/Gini/BPM/Camunda/Engine.php
@@ -183,7 +183,7 @@ class Engine implements \Gini\BPM\Driver\Engine {
         $engine = $this->config['options']['engine'];
 
         if(empty($files)) {
-            throw new \Gini\BPM\Exception("empty files", 400);
+            throw new \Gini\BPM\Exception("empty files");
         }
 
         $data = [];


### PR DESCRIPTION
场景：前台的 BPMN/DMN 插件提交过来的 xml 信息格式是字符串而不是文件，增加一个方法可以在该场景下直接 deploy 到 camunda 引擎。